### PR TITLE
Fix model name persistence - reduce to 8 models

### DIFF
--- a/src/core/iosettings.c
+++ b/src/core/iosettings.c
@@ -554,7 +554,7 @@ void STsaveSettingsToFlash(void)
 	W25qxx_WriteSector((uint8_t *)&CommonSettings, SYSTEM_SETTINGS_FLASH_SECTOR_A, 0, sizeof(CommonSettings));
 
 	/*
-	 * Save model profiles.
+	 * Save model profiles (9 models fit in 1 sector after reducing from 13 to 8 models).
 	 */
 	W25qxx_EraseSector(MODEL_PROFILE_FLASH_SECTOR);
 	W25qxx_WriteSector((uint8_t *)ModelSettings, MODEL_PROFILE_FLASH_SECTOR, 0, sizeof(ModelSettings));

--- a/src/gui/screens/modelprofilemenu.c
+++ b/src/gui/screens/modelprofilemenu.c
@@ -39,6 +39,8 @@ STbuttonTypeDef BackToModelProfileButton = { 0 };		//
 void _ModelProfile() {
 	if (STscreenShowNow(&ModelProfileST)) {
 
+		static uint16_t name_edit_flag = 0;
+
 		/*
 		 * ������� � �������� ����
 		 */
@@ -72,12 +74,14 @@ void _ModelProfile() {
 		 */
 		if (STbuttonPressed(&ModelNameMP)) {
 			STappSetScreen(Keyboard, &STApp);
+			name_edit_flag = Yes;
 		}
 
-		if (STappGetTextBuffState(&STApp) == Yes) {
+		if (name_edit_flag && STappGetTextBuffState(&STApp) == Yes) {
 			strlcpy(ModelSettings[STgetCurrentModelID()].Name, STappGetInputTextBuff(&STApp),	MAX_RC_NAME);
 			STappClearBuff(&STApp);
 			STrequestSettingsSave();
+			name_edit_flag = No;
 		}
 
 		/*

--- a/src/stconfig.h
+++ b/src/stconfig.h
@@ -54,7 +54,7 @@
 /**********************************
  *Memory
  *********************************/
-#define MODEL_MEMORY_NUM 12
+#define MODEL_MEMORY_NUM 8
 #define MODEL_FLASH_NUM MODEL_MEMORY_NUM + 1
 
 #define MODEL_PROFILE_STORAGE 1 /* 0 - Internal flash \

--- a/src/version.h
+++ b/src/version.h
@@ -43,7 +43,7 @@
 
 #define FW_VERSION_MAJOR            2  // increment when a major release is made (big new feature, etc)
 #define FW_VERSION_MINOR            4  // increment when a minor release is made (small new feature, change etc)
-#define FW_VERSION_PATCH_LEVEL      0  // increment when a bug is fixed
+#define FW_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
 
 #define FW_VERSION_STRING STR(FW_VERSION_MAJOR) "." STR(FW_VERSION_MINOR) "." STR(FW_VERSION_PATCH_LEVEL)
 


### PR DESCRIPTION
Problem: Model names not persisting after power cycle due to W25Q16 sector overflow. ModelSettings was ~6.5KB but sector = 4KB.

Solution: Reduce MODEL_MEMORY_NUM from 12 to 8, now fits in 1 sector. Added protection flag in modelprofilemenu.c to prevent re-execution.